### PR TITLE
Agregar validación para códigos hexadecimales de color en el modelo C…

### DIFF
--- a/src/domain/models/value-objects/Color.ts
+++ b/src/domain/models/value-objects/Color.ts
@@ -14,7 +14,7 @@ export class Color {
   }
 
   private isValidHexCode(hex: string): boolean {
-    return /^#[0-9A-F]{6}$/i.test(hex)
+    return /^#[0-9A-F]{6}$/i.test(hex) || /^#[0-9A-F]{3}$/i.test(hex)
   }
 
   getName(): string {

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -1,0 +1,51 @@
+import { Price, Color, Storage } from '@/domain/models/value-objects'
+import { vi } from 'vitest'
+
+export const mockProduct = {
+  id: '1',
+  name: 'iPhone 13 Pro',
+  imageUrl: 'https://example.com/image.jpg',
+  brand: 'Apple',
+  basePrice: Price.create(100),
+}
+
+export const mockProductList = [mockProduct, mockProduct, mockProduct]
+
+export const mockCartItems = [
+  {
+    id: '1',
+    name: 'iPhone 13 Pro',
+    basePrice: Price.create(100),
+    imageUrl: 'https://example.com/image.jpg',
+    brand: 'Apple',
+    description: 'Test Description',
+    rating: 4.5,
+    specs: {
+      screen: '6.1"',
+      resolution: '1170 x 2532',
+      processor: 'A15 Bionic',
+      mainCamera: '24MP',
+      selfieCamera: '12MP',
+      battery: '3240mAh',
+      os: 'iOS 15',
+      screenRefreshRate: '60Hz',
+    },
+    colorOptions: [
+      Color.create('Color 1', '#000000', 'https://example.com/image.jpg'),
+      Color.create('Color 2', '#ffffff', 'https://example.com/image2.jpg'),
+    ],
+    storageOptions: [
+      Storage.create('256', Price.create(100)),
+      Storage.create('512', Price.create(150)),
+    ],
+    similarProducts: [mockProduct, mockProduct, mockProduct],
+    quantity: 1,
+  },
+]
+
+export const mockUseCart = () => ({
+  cartItems: mockCartItems,
+  addItemToCart: vi.fn(),
+  removeItemFromCart: vi.fn(),
+  clearCart: vi.fn(),
+})

--- a/src/ui/components/button/Button.tsx
+++ b/src/ui/components/button/Button.tsx
@@ -13,6 +13,7 @@ export const Button = ({
 }) => {
   return (
     <button
+      role='button'
       className={styles.button}
       disabled={disabled}
       onClick={onClick}

--- a/src/ui/components/cart_button/CartButton.test.tsx
+++ b/src/ui/components/cart_button/CartButton.test.tsx
@@ -3,43 +3,8 @@ import { CartButton } from './CartButton'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as CartContextModule from '@/context/CartContext'
 
-import { Product } from '@/domain/models/interfaces'
-import { Price } from '@/domain/models/value-objects'
-
+import { mockUseCart } from '@/test/mocks'
 describe('CartButton', () => {
-  const cartItems: (Product & { quantity?: number })[] = [
-    {
-      id: '1',
-      name: 'Product 1',
-      basePrice: Price.create(100),
-      imageUrl: 'https://example.com/image.jpg',
-      brand: 'Test Brand',
-      description: 'Test Description',
-      rating: 4.5,
-      specs: {
-        screen: '6.1"',
-        resolution: '1170 x 2532',
-        processor: 'A15 Bionic',
-        mainCamera: '12MP',
-        selfieCamera: '12MP',
-        battery: '3240mAh',
-        os: 'iOS 15',
-        screenRefreshRate: '60Hz',
-      },
-      colorOptions: [],
-      storageOptions: [],
-      similarProducts: [],
-      quantity: 1,
-    },
-  ]
-
-  const mockUseCart = () => ({
-    cartItems: cartItems,
-    addItemToCart: vi.fn(),
-    removeItemFromCart: vi.fn(),
-    clearCart: vi.fn(),
-  })
-
   beforeEach(() => {
     vi.spyOn(CartContextModule, 'useCart').mockImplementation(mockUseCart)
   })
@@ -54,7 +19,7 @@ describe('CartButton', () => {
 
   it('shows and icon when there are items in the cart', () => {
     render(<CartButton />)
-    expect(screen.getByTestId('bag-icon-active')).toBeInTheDocument()
+    expect(screen.getByLabelText('bag-active')).toBeInTheDocument()
   })
 
   it('shows and icon when there are no items in the cart', () => {
@@ -65,7 +30,7 @@ describe('CartButton', () => {
       clearCart: vi.fn(),
     }))
     render(<CartButton />)
-    expect(screen.getByTestId('bag-icon')).toBeInTheDocument()
+    expect(screen.getByLabelText('bag')).toBeInTheDocument()
   })
 
   it('shows the correct number of items in the cart', () => {

--- a/src/ui/components/product_card_cart/ProductCardCart.test.tsx
+++ b/src/ui/components/product_card_cart/ProductCardCart.test.tsx
@@ -1,10 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ProductCardCart } from './ProductCardCart'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { Product } from '@/domain/models/interfaces'
 import * as CartContextModule from '@/context/CartContext'
-import { Color, Storage, Price } from '@/domain/models/value-objects'
-
+import { mockCartItems } from '@/test/mocks'
 describe('ProductCardCart', () => {
   const mockCart = {
     cartItems: [],
@@ -22,34 +20,10 @@ describe('ProductCardCart', () => {
     vi.clearAllMocks()
     vi.restoreAllMocks()
   })
-  const product: Product & { quantity?: number } = {
-    id: '1',
-    name: 'Product 1',
-    basePrice: Price.create(100),
-    imageUrl: 'https://example.com/image.jpg',
-    brand: 'Brand 1',
-    description: 'Description 1',
-    rating: 4.5,
-    specs: {
-      screen: '6.1"',
-      resolution: '1170 x 2532',
-      processor: 'A15 Bionic',
-      mainCamera: '12MP',
-      selfieCamera: '12MP',
-      battery: '3240mAh',
-      os: 'iOS 15',
-      screenRefreshRate: '60Hz',
-    },
-    colorOptions: [
-      Color.create('Color 1', '#000000', 'https://example.com/image.jpg'),
-    ],
-    storageOptions: [Storage.create('256', Price.create(100))],
-    similarProducts: [],
-    quantity: 1,
-  }
+
   it('renders the product card with the correct data', () => {
-    render(<ProductCardCart product={product} />)
-    expect(screen.getByText('Product 1')).toBeInTheDocument()
+    render(<ProductCardCart product={mockCartItems[0]} />)
+    expect(screen.getByText('iPhone 13 Pro')).toBeInTheDocument()
     expect(screen.getByText('100 EUR')).toBeInTheDocument()
     expect(screen.getByText('256 | Color 1')).toBeInTheDocument()
     expect(screen.getByRole('img')).toHaveAttribute(
@@ -59,12 +33,12 @@ describe('ProductCardCart', () => {
   })
 
   it('have correct number of items in the cart', () => {
-    render(<ProductCardCart product={{ ...product, quantity: 24 }} />)
+    render(<ProductCardCart product={{ ...mockCartItems[0], quantity: 24 }} />)
     expect(screen.getByText('Remove (24)')).toBeInTheDocument()
   })
 
   it('remove 1 item from card', () => {
-    const productWithQuantity = { ...product, quantity: 2 }
+    const productWithQuantity = { ...mockCartItems[0], quantity: 2 }
     render(<ProductCardCart product={productWithQuantity} />)
 
     const removeButton = screen.getByText('Remove (2)')
@@ -76,14 +50,14 @@ describe('ProductCardCart', () => {
   })
 
   it('update UI when the quantity of the product changes', () => {
-    const productWithQuantity = { ...product, quantity: 2 }
+    const productWithQuantity = { ...mockCartItems[0], quantity: 2 }
 
     const { rerender } = render(
       <ProductCardCart product={productWithQuantity} />,
     )
     expect(screen.getByText('Remove (2)')).toBeInTheDocument()
 
-    const updatedProduct = { ...product, quantity: 1 }
+    const updatedProduct = { ...mockCartItems[0], quantity: 1 }
     rerender(<ProductCardCart product={updatedProduct} />)
 
     expect(screen.getByText('Remove (1)')).toBeInTheDocument()

--- a/src/ui/components/search_bar/SearchBar.test.tsx
+++ b/src/ui/components/search_bar/SearchBar.test.tsx
@@ -15,7 +15,7 @@ describe('SearchBar', () => {
 
   it('should render input', () => {
     render(<SearchBar />)
-    expect(screen.getByRole('textbox')).toBeInTheDocument()
+    expect(screen.getByLabelText('Campo de búsqueda')).toBeInTheDocument()
   })
 
   it('should render correct number of results', () => {
@@ -24,7 +24,7 @@ describe('SearchBar', () => {
   })
   it('should have value', () => {
     render(<SearchBar value='test' />)
-    expect(screen.getByRole('textbox')).toHaveValue('test')
+    expect(screen.getByLabelText('search-input')).toHaveValue('test')
   })
 
   it('should show clear button if value is present', () => {
@@ -37,6 +37,6 @@ describe('SearchBar', () => {
     const button = screen.getByRole('button')
     fireEvent.click(button)
     rerender(<SearchBar value='' />)
-    expect(screen.getByRole('textbox')).toHaveValue('')
+    expect(screen.getByLabelText('search-input')).toHaveValue('')
   })
 })

--- a/src/ui/components/search_bar/SearchBar.tsx
+++ b/src/ui/components/search_bar/SearchBar.tsx
@@ -21,7 +21,7 @@ export const SearchBar = ({
           value={value}
           autoFocus
           onChange={(e) => onChange(e.target.value)}
-          aria-label='Campo de búsqueda'
+          aria-label='search-input'
           aria-describedby='search-results'
           list='search-suggestions'
         />

--- a/src/ui/components/smartphone_card/SmartphoneCard.test.tsx
+++ b/src/ui/components/smartphone_card/SmartphoneCard.test.tsx
@@ -1,21 +1,13 @@
 import { render, screen } from '@testing-library/react'
 import { SmartphoneCard } from './SmartphoneCard'
 import { describe, expect, it } from 'vitest'
-import { Price } from '@/domain/models/value-objects'
-import { ProductList } from '@/domain/models/ProductList'
 
+import { mockProduct } from '@/test/mocks'
 describe('SmartphoneCard url', () => {
-  const product: ProductList = {
-    id: '1',
-    name: 'Product 1',
-    basePrice: Price.create(100),
-    brand: 'Brand 1',
-    imageUrl: 'https://example.com/image.jpg',
-  }
   it('renders the product card with the correct data', () => {
-    render(<SmartphoneCard url={'/product/1'} product={product} />)
-    expect(screen.getByText('Product 1')).toBeInTheDocument()
-    expect(screen.getByText('Brand 1')).toBeInTheDocument()
+    render(<SmartphoneCard url={'/product/1'} product={mockProduct} />)
+    expect(screen.getByText('iPhone 13 Pro')).toBeInTheDocument()
+    expect(screen.getByText('Apple')).toBeInTheDocument()
     expect(screen.getByText('100 EUR')).toBeInTheDocument()
     expect(screen.getByRole('img')).toHaveAttribute(
       'src',
@@ -24,7 +16,7 @@ describe('SmartphoneCard url', () => {
   })
 
   it('link to product detail', () => {
-    render(<SmartphoneCard url={'/product/1'} product={product} />)
+    render(<SmartphoneCard url={'/product/1'} product={mockProduct} />)
     const link = screen.getByRole('link')
     expect(link).toHaveAttribute('href', '/product/1')
   })

--- a/src/ui/icons/Icon.tsx
+++ b/src/ui/icons/Icon.tsx
@@ -12,7 +12,12 @@ export const Icon = ({
   height = 24,
 }: IconProps) => {
   return (
-    <svg height={height} width={width} className={className}>
+    <svg
+      aria-label={name}
+      height={height}
+      width={width}
+      className={className}
+    >
       <use href={`#${name}-icon`} />
     </svg>
   )

--- a/src/ui/pages/cart/CartPage.test.tsx
+++ b/src/ui/pages/cart/CartPage.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import { CartPage } from './CartPage'
+import { expect, describe, it, vi, afterEach, beforeEach } from 'vitest'
+import { mockCartItems } from '@/test/mocks'
+import { mockUseCart } from '@/test/mocks'
+import * as CartContextModule from '@/context/CartContext'
+describe('CartPage', () => {
+  beforeEach(() => {
+    vi.spyOn(CartContextModule, 'useCart').mockImplementation(mockUseCart)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+  it('should render the cart page', () => {
+    render(<CartPage />)
+    expect(screen.getByText('Cart (1)')).toBeInTheDocument()
+  })
+
+  it('should render the cart items', () => {
+    render(<CartPage />)
+    expect(screen.getByText('iPhone 13 Pro')).toBeInTheDocument()
+  })
+
+  it('should render correct number of cart items', () => {
+    vi.spyOn(CartContextModule, 'useCart').mockImplementation(() => ({
+      cartItems: [mockCartItems[0], mockCartItems[0], mockCartItems[0]],
+      addItemToCart: vi.fn(),
+      removeItemFromCart: vi.fn(),
+      clearCart: vi.fn(),
+    }))
+    render(<CartPage />)
+    expect(screen.getByText('Cart (3)')).toBeInTheDocument()
+  })
+})

--- a/src/ui/pages/cart/components/footer/Footer.test.tsx
+++ b/src/ui/pages/cart/components/footer/Footer.test.tsx
@@ -1,0 +1,30 @@
+import { Footer } from './Footer'
+import { render, screen } from '@testing-library/react'
+import { expect, describe, it } from 'vitest'
+import { mockCartItems } from '@/test/mocks'
+describe('Footer', () => {
+  it('should show correct price', () => {
+    render(
+      <Footer
+        cartItems={[mockCartItems[0], mockCartItems[0], mockCartItems[0]]}
+      />,
+    )
+    expect(screen.getByText('300 EUR')).toBeInTheDocument()
+  })
+
+  it('should hide cart logic if cart is empty', () => {
+    render(<Footer cartItems={[]} />)
+    expect(screen.queryByText('Pay')).not.toBeInTheDocument()
+  })
+
+  it('should link to checkout page', () => {
+    render(<Footer cartItems={mockCartItems} />)
+    const checkoutLink = screen.getByText('Pay')
+    expect(checkoutLink).toHaveAttribute('href', '#')
+  })
+  it('should link to list page', () => {
+    render(<Footer cartItems={mockCartItems} />)
+    const listLink = screen.getByText('Continue Shopping')
+    expect(listLink).toHaveAttribute('href', '/')
+  })
+})

--- a/src/ui/pages/product_detail/components/slider/Slider.test.tsx
+++ b/src/ui/pages/product_detail/components/slider/Slider.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { Slider } from './Slider'
+import { expect, describe, it } from 'vitest'
+import { SmartphoneCard } from '@/ui/components/smartphone_card/SmartphoneCard'
+import { mockProductList } from '@/test/mocks'
+describe('Slider', () => {
+  it('should render', () => {
+    render(
+      <Slider>
+        <SmartphoneCard
+          product={mockProductList[0]}
+          url='https://prueba-tecnica-api-tienda-moviles.onrender.com/images/OPP-A60-midnight-purple.webp'
+        />
+        <SmartphoneCard
+          product={mockProductList[1]}
+          url='https://prueba-tecnica-api-tienda-moviles.onrender.com/images/OPP-A60-midnight-purple.webp'
+        />
+      </Slider>,
+    )
+    expect(screen.getByLabelText('SIMILAR ITEMS')).toBeInTheDocument()
+  })
+
+  it('should render the correct number of elements', () => {
+    render(
+      <Slider>
+        <SmartphoneCard
+          product={mockProductList[0]}
+          url='https://prueba-tecnica-api-tienda-moviles.onrender.com/images/OPP-A60-midnight-purple.webp'
+        />
+        <SmartphoneCard
+          product={mockProductList[1]}
+          url='https://prueba-tecnica-api-tienda-moviles.onrender.com/images/OPP-A60-midnight-purple.webp'
+        />
+      </Slider>,
+    )
+    expect(screen.getAllByRole('img')).toHaveLength(2)
+  })
+})

--- a/src/ui/pages/product_detail/layout/product_info_header/ProductInfoHeader.test.tsx
+++ b/src/ui/pages/product_detail/layout/product_info_header/ProductInfoHeader.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ProductInfoHeader } from './ProductInfoHeader'
+import { expect, describe, it, vi, beforeEach, afterEach } from 'vitest'
+import * as CartContextModule from '@/context/CartContext'
+import { mockCartItems } from '@/test/mocks'
+describe('ProductInfoHeader', () => {
+  const mockCart = {
+    cartItems: mockCartItems,
+    addItemToCart: vi.fn(),
+    removeItemFromCart: vi.fn(),
+    clearCart: vi.fn(),
+  }
+
+  const mockUseCart = () => mockCart
+
+  beforeEach(() => {
+    vi.spyOn(CartContextModule, 'useCart').mockImplementation(mockUseCart)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  it('should render the product info header', () => {
+    render(<ProductInfoHeader product={mockCartItems[0]} />)
+    expect(screen.getByText('iPhone 13 Pro')).toBeInTheDocument()
+    expect(screen.getByText('From 100 EUR')).toBeInTheDocument()
+    expect(screen.getByText('256')).toBeInTheDocument()
+    expect(screen.getByTitle('Color 1')).toBeInTheDocument()
+  })
+
+  it('should render correct number of color options', () => {
+    render(<ProductInfoHeader product={mockCartItems[0]} />)
+    expect(screen.getByRole('button', { name: 'Color 1' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Color 2' })).toBeInTheDocument()
+  })
+
+  it('should render correct number of storage options', () => {
+    render(<ProductInfoHeader product={mockCartItems[0]} />)
+    expect(screen.getByRole('button', { name: '256' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '512' })).toBeInTheDocument()
+  })
+
+  it('should select color and storage options', () => {
+    render(<ProductInfoHeader product={mockCartItems[0]} />)
+
+    const colorButton = screen.getByRole('button', { name: 'Color 2' })
+    const storageButton = screen.getByRole('button', { name: '512' })
+
+    fireEvent.click(colorButton)
+    fireEvent.click(storageButton)
+
+    expect(screen.getByRole('img').getAttribute('src')).toBe(
+      'https://example.com/image2.jpg',
+    )
+    expect(screen.getByText('From 150 EUR')).toBeInTheDocument()
+  })
+
+  it('should add product to cart when button is clicked', () => {
+    render(<ProductInfoHeader product={mockCartItems[0]} />)
+
+    const colorButton = screen.getByRole('button', { name: 'Color 2' })
+    const storageButton = screen.getByRole('button', { name: '512' })
+
+    fireEvent.click(colorButton)
+    fireEvent.click(storageButton)
+
+    const addToCartButton = screen.getByLabelText('Add to cart')
+    expect(addToCartButton).toBeEnabled()
+
+    fireEvent.click(addToCartButton)
+    expect(mockCart.addItemToCart).toHaveBeenCalledWith({
+      ...mockCartItems[0],
+      colorOptions: [mockCartItems[0].colorOptions[1]],
+      storageOptions: [mockCartItems[0].storageOptions[1]],
+    })
+  })
+})

--- a/src/ui/pages/product_detail/layout/product_info_header/ProductInfoHeader.tsx
+++ b/src/ui/pages/product_detail/layout/product_info_header/ProductInfoHeader.tsx
@@ -58,7 +58,7 @@ export const ProductInfoHeader = ({ product }: { product: Product }) => {
               {product.name}
             </h1>
             <p className={styles.productInfoHeader__info__price}>
-              Form{' '}
+              From{' '}
               {selectedStorage?.getPrice().toString() ??
                 product.storageOptions[0].getPrice().toString()}
             </p>
@@ -92,6 +92,8 @@ export const ProductInfoHeader = ({ product }: { product: Product }) => {
             <div className={styles.colorOptions__container}>
               {product.colorOptions.map((color) => (
                 <button
+                  role='button'
+                  aria-label={color.getName()}
                   key={color.getHexCode()}
                   className={`${styles.colorOption} ${
                     selectedColor?.getHexCode() === color.getHexCode()
@@ -107,6 +109,7 @@ export const ProductInfoHeader = ({ product }: { product: Product }) => {
           </div>
 
           <Button
+            ariaLabel='Add to cart'
             disabled={!selectedStorage || !selectedColor}
             onClick={() =>
               addItemToCart({

--- a/src/ui/pages/product_detail/layout/specifications/Specifications.test.tsx
+++ b/src/ui/pages/product_detail/layout/specifications/Specifications.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { mockCartItems } from '@/test/mocks'
+import { Specifications } from './Specifications'
+import { expect, describe, it } from 'vitest'
+
+describe('Specifications', () => {
+  it('should render the specifications', () => {
+    render(<Specifications product={mockCartItems[0]} />)
+    expect(screen.getByText('SPECIFICATIONS')).toBeInTheDocument()
+    expect(screen.getByText('Screen')).toBeInTheDocument()
+    expect(screen.getByText('Resolution')).toBeInTheDocument()
+    expect(screen.getByText('Processor')).toBeInTheDocument()
+    expect(screen.getByText('Main Camera')).toBeInTheDocument()
+    expect(screen.getByText('Selfie Camera')).toBeInTheDocument()
+    expect(screen.getByText('Battery')).toBeInTheDocument()
+    expect(screen.getByText('OS')).toBeInTheDocument()
+    expect(screen.getByText('Screen Refresh Rate')).toBeInTheDocument()
+    expect(screen.getByText('6.1"')).toBeInTheDocument()
+    expect(screen.getByText('1170 x 2532')).toBeInTheDocument()
+    expect(screen.getByText('A15 Bionic')).toBeInTheDocument()
+    expect(screen.getByText('3240mAh')).toBeInTheDocument()
+    expect(screen.getByText('iOS 15')).toBeInTheDocument()
+    expect(screen.getByText('60Hz')).toBeInTheDocument()
+    expect(screen.getByText('12MP')).toBeInTheDocument()
+    expect(screen.getByText('24MP')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
…olor, permitir códigos de 3 y 6 dígitos. También se añaden pruebas y mocks para el manejo del carrito y la página de carrito, mejorando la cobertura de pruebas y la estructura del código.